### PR TITLE
Support for HtmlContent for operations

### DIFF
--- a/jminix/src/main/java/org/jminix/console/resource/AbstractTemplateResource.java
+++ b/jminix/src/main/java/org/jminix/console/resource/AbstractTemplateResource.java
@@ -17,17 +17,32 @@
 
 package org.jminix.console.resource;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanServerConnection;
+
 import net.sf.json.JSONSerializer;
+
 import org.apache.velocity.Template;
 import org.apache.velocity.app.VelocityEngine;
 import org.jminix.server.ServerConnectionProvider;
 import org.jminix.type.HtmlContent;
+import org.jminix.type.InputStreamContent;
 import org.restlet.data.CacheDirective;
 import org.restlet.data.CharacterSet;
 import org.restlet.data.Language;
 import org.restlet.data.MediaType;
 import org.restlet.ext.velocity.TemplateRepresentation;
 import org.restlet.representation.EmptyRepresentation;
+import org.restlet.representation.InputRepresentation;
 import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
 import org.restlet.representation.Variant;
@@ -35,14 +50,10 @@ import org.restlet.resource.Get;
 import org.restlet.resource.ResourceException;
 import org.restlet.resource.ServerResource;
 
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanServerConnection;
-import java.util.*;
-
 public abstract class AbstractTemplateResource extends ServerResource
 {
-	public String a;
-	
+    public String a;
+
     private final static String VELOCITY_ENGINE_CONTEX_KEY = "template.resource.velocity.engine";
     protected final EncoderBean encoder = new EncoderBean();
 
@@ -100,11 +111,16 @@ public abstract class AbstractTemplateResource extends ServerResource
 
         if (MediaType.TEXT_HTML.equals(variant.getMediaType()))
         {
-
             Map<String, Object> enrichedModel = new HashMap<String, Object>(model);
 
             String templateName = getTemplateName();
-            if(enrichedModel.get("value") instanceof HtmlContent) {
+            Object resultObject = enrichedModel.get("value");
+            
+            if (resultObject instanceof InputStreamContent) {
+                return new InputRepresentation((InputStreamContent) resultObject, MediaType.APPLICATION_OCTET_STREAM);
+            }
+
+            if (resultObject instanceof HtmlContent) {
             	templateName = "html-attribute";
             }
             
@@ -125,11 +141,11 @@ public abstract class AbstractTemplateResource extends ServerResource
             
             String skin = getRequest().getResourceRef().getQueryAsForm().getValues("skin");                       
             if(skin==null) {
-            	skin="default";
+                skin="default";
             }
             String desc = getRequest().getResourceRef().getQueryAsForm().getValues("desc");  
             if(desc==null) {
-            	desc="on";
+                desc="on";
             }
             enrichedModel.put("query", getQueryString());
             enrichedModel.put("ok", "1".equals(getRequest().getResourceRef().getQueryAsForm().getValues("ok")));
@@ -222,21 +238,21 @@ public abstract class AbstractTemplateResource extends ServerResource
             {
                 if (model.containsKey("value"))
                 {
-                	if(model.get("value") instanceof HtmlContent) {
-                		result.put("value", "...");
-                	} else {
-                		result.put("value", model.get("value").toString());
-                	}
+                    if(model.get("value") instanceof HtmlContent) {
+                        result.put("value", "...");
+                    } else {
+                        result.put("value", model.get("value").toString());
+                    }
                 }
                 else if (model.containsKey("items"))
                 {
-                	Object items = model.get("items");
-                	String value = null;
-                	if(items.getClass().isArray()) {
-                		value = Arrays.deepToString(Arrays.asList(items).toArray());
-                	} else {
-                		value = items.toString();
-                	}
+                    Object items = model.get("items");
+                    String value = null;
+                    if(items.getClass().isArray()) {
+                        value = Arrays.deepToString(Arrays.asList(items).toArray());
+                    } else {
+                        value = items.toString();
+                    }
                     result.put("value", value);
                 }
             }
@@ -272,8 +288,8 @@ public abstract class AbstractTemplateResource extends ServerResource
     }
     
     protected String getQueryString() {
-    	String query = getRequest().getResourceRef().getQuery();
-    	return query!=null ? "?"+query : "";
+        String query = getRequest().getResourceRef().getQuery();
+        return query!=null ? "?"+query : "";
     }
 
     protected String getDecodedAttribute(String value) {

--- a/jminix/src/main/java/org/jminix/console/resource/OperationResource.java
+++ b/jminix/src/main/java/org/jminix/console/resource/OperationResource.java
@@ -17,24 +17,34 @@
 
 package org.jminix.console.resource;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.management.InstanceNotFoundException;
+import javax.management.IntrospectionException;
+import javax.management.MBeanException;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+
 import net.sf.json.JSONSerializer;
 
 import org.jminix.type.HtmlContent;
+import org.jminix.type.InputStreamContent;
 import org.restlet.data.CharacterSet;
 import org.restlet.data.Form;
 import org.restlet.data.Language;
 import org.restlet.data.MediaType;
+import org.restlet.representation.InputRepresentation;
 import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
 import org.restlet.representation.Variant;
 import org.restlet.resource.Post;
 import org.restlet.resource.ResourceException;
-
-import javax.management.*;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 public class OperationResource extends AbstractTemplateResource
 {
@@ -96,25 +106,29 @@ public class OperationResource extends AbstractTemplateResource
             Object result = server.invoke(new ObjectName(domain+":"+mbean), operation, params, signature);
 
             if(result != null) {
-            	Variant variant = getPreferredVariant(getVariants());
-            	if (MediaType.APPLICATION_JSON == variant.getMediaType()) {
+                Variant variant = getPreferredVariant(getVariants());
+                if (MediaType.APPLICATION_JSON == variant.getMediaType()) {
                     return new StringRepresentation( JSONSerializer.toJSON(result).toString(),
                             MediaType.APPLICATION_JSON, Language.ALL, CharacterSet.UTF_8);
-            	} else {
-                    return new StringRepresentation( result.toString(),
-                            result instanceof HtmlContent ? MediaType.TEXT_HTML : MediaType.TEXT_PLAIN, 
-                            Language.ALL, CharacterSet.UTF_8);
-            	}
+                } else {
+                    if (result instanceof InputStreamContent) {
+                        return new InputRepresentation((InputStreamContent) result, MediaType.APPLICATION_OCTET_STREAM);
+                    } else {
+                        return new StringRepresentation(result.toString(),
+                                result instanceof HtmlContent ? MediaType.TEXT_HTML : MediaType.TEXT_PLAIN,
+                                Language.ALL, CharacterSet.UTF_8);
+                    }
+                }
             } else {
-            	String queryString = getQueryString();
-            	if(!queryString.contains("ok=1")) {
-                	if(queryString==null || "".equals(queryString)) {
-                		queryString = "?";
-                	} else {
-                		queryString += "&";
-                	}
-                	queryString+="ok=1";
-            	}
+                String queryString = getQueryString();
+                if(!queryString.contains("ok=1")) {
+                    if(queryString==null || "".equals(queryString)) {
+                        queryString = "?";
+                    } else {
+                        queryString += "&";
+                    }
+                    queryString+="ok=1";
+                }
                 redirectPermanent(encoder.encode(declaration)+queryString);
                 return null;
             }

--- a/jminix/src/main/java/org/jminix/type/InputStreamContent.java
+++ b/jminix/src/main/java/org/jminix/type/InputStreamContent.java
@@ -1,0 +1,10 @@
+package org.jminix.type;
+
+import java.io.InputStream;
+
+/**
+ * Marker interface that allows direct download from JMiniX.
+ */
+public abstract class InputStreamContent extends InputStream {
+
+}

--- a/jminix/src/test/java/org/jminix/console/JMiniXStuff.java
+++ b/jminix/src/test/java/org/jminix/console/JMiniXStuff.java
@@ -1,0 +1,90 @@
+package org.jminix.console;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jminix.type.HtmlContent;
+import org.jminix.type.InputStreamContent;
+
+public final class JMiniXStuff implements JMiniXStuffMBean {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getSimpleString() {
+        return "This is a simple String";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String invokeStringOperation() {
+        return "This text comes from 'invokeStringOperation'.";
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HtmlContent getHtmlString() {
+        return new HtmlContent() {
+            private static final long serialVersionUID = -1997969459356542938L;
+
+            public String toString() {
+                return "JMiniX can be found <a href=\"https://code.google.com/p/jminix/\">here</a>";
+            }
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HtmlContent invokeHtmlStringOperation() {
+        return new HtmlContent() {
+            private static final long serialVersionUID = -1997969459356542938L;
+
+            public String toString() {
+                StringBuilder sb = new StringBuilder();
+                sb.append("My bookmarks (from 'invokeHtmlStringOperation')<hr>");
+                sb.append("<a href=\"https://code.google.com/p/jminix/\">JMiniX Homepage</a><br>");
+                sb.append("<a href=\"https://github.com/lbovet/jminix/\">JMiniX on GitHub</a>");
+                return sb.toString();
+            }
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InputStreamContent getInputStream() {
+        return new InputStreamContent() {
+            private InputStream is = new ByteArrayInputStream("This file comes from getInputStream".getBytes());
+
+            @Override
+            public int read() throws IOException {
+                return is.read();
+            }
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public InputStreamContent invokeStreamOperation() {
+        return new InputStreamContent() {
+            private InputStream is = new ByteArrayInputStream(
+                    "This file comes from invokeStreamOperation".getBytes());
+
+            @Override
+            public int read() throws IOException {
+                return is.read();
+            }
+        };
+    }
+}

--- a/jminix/src/test/java/org/jminix/console/JMiniXStuffMBean.java
+++ b/jminix/src/test/java/org/jminix/console/JMiniXStuffMBean.java
@@ -1,0 +1,41 @@
+package org.jminix.console;
+
+import org.jminix.type.HtmlContent;
+import org.jminix.type.InputStreamContent;
+
+/**
+ * Our Test MBean.
+ */
+public interface JMiniXStuffMBean {
+
+    /**
+     * Attribute that returns a simple String.
+     */
+    public String getSimpleString();
+
+    /**
+     * Operation that Returns a simple String.
+     */
+    public abstract String invokeStringOperation();
+
+    /**
+     * Attribute that returns a HTML String.
+     */
+    public abstract HtmlContent getHtmlString();
+
+    /**
+     * Operation that returns a HTML String.
+     */
+    public abstract HtmlContent invokeHtmlStringOperation();
+
+    /**
+     * Attribute that returns an {@link InputStreamContent}.
+     */
+    public abstract InputStreamContent getInputStream();
+
+    /**
+     * Operation that returns an {@link InputStreamContent}.
+     */
+    public abstract InputStreamContent invokeStreamOperation();
+
+}

--- a/jminix/src/test/java/org/jminix/console/Main.java
+++ b/jminix/src/test/java/org/jminix/console/Main.java
@@ -17,11 +17,26 @@
 
 package org.jminix.console;
 
+import java.lang.management.ManagementFactory;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+
 import org.jminix.console.tool.StandaloneMiniConsole;
 
 public class Main
 {
-    public final static void main(String[] args) {
+    public final static void main(String[] args) throws MalformedObjectNameException, 
+    InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException {
+
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectName name = new ObjectName("org.jminix.console:type=JMiniXStuff");
+        mbs.registerMBean(new JMiniXStuff(), name);
+
         new StandaloneMiniConsole(8088);
     }
 }


### PR DESCRIPTION
- added support of HtmlContent for JMX operations (was supported just for attributes). 
- introduction of a new interface InputStreamContent. If a attribute or operation returns this interface, the browser will download all data from this input stream. I added this so now I can create **AND** automaticall download a java heap dump from within JMiniX. Sadly I found no way to force a filename for the download (a filename can be specified using the Disposition class, but sadly gets ignored).
- I also added a little sample MBean that demonstrates the usage of HtmlContent and InputStreamContent. This sample MBean can be accessed when running the sample org.jminix.console.Main application.
