### PR TITLE
Fallback to extract POST params

### DIFF
--- a/src/main/java/org/jminix/console/resource/OperationResource.java
+++ b/src/main/java/org/jminix/console/resource/OperationResource.java
@@ -18,8 +18,10 @@
 package org.jminix.console.resource;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.StreamSupport;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
@@ -39,6 +41,7 @@ import org.restlet.data.CharacterSet;
 import org.restlet.data.Form;
 import org.restlet.data.Language;
 import org.restlet.data.MediaType;
+import org.restlet.ext.servlet.ServletUtils;
 import org.restlet.representation.InputRepresentation;
 import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
@@ -77,7 +80,10 @@ public class OperationResource extends AbstractTemplateResource
     public Representation execute(Representation entity) throws ResourceException
     {
         String[] stringParams = new Form(entity).getValuesArray("param");
-
+        
+        if(stringParams != null && isAllNulls(Arrays.asList(stringParams))) {
+            stringParams = (String[]) ServletUtils.getRequest(getRequest()).getParameterMap().get("param");
+        }
 
         String domain = unescape(getDecodedAttribute("domain"));
 
@@ -214,5 +220,8 @@ public class OperationResource extends AbstractTemplateResource
             throw new RuntimeException(e);
         }
     }
-
+    
+    private boolean isAllNulls(Iterable<?> array) {
+        return StreamSupport.stream(array.spliterator(), true).allMatch(o -> o == null);
+    }
 }


### PR DESCRIPTION
There are many differents ways [0],[1],[2] to cause restlet some
problems parsing the POST form.

This change introduces a fallback to get the paramters anyway.

Fixes issue lbovet#11

[0] https://stackoverflow.com/questions/72102206/wildfly-26-changed-behaviour-of-rest-with-content-type-x-www-form-urlencoded
[1] https://stackoverflow.com/questions/9985892/restlet-appears-to-be-doubly-decoding-my-form-parameters/11949673#11949673
[2] https://github.com/restlet/restlet-framework-java/issues/1345