### PR TITLE
Updates jgroups to 4.0, fixes CVE-2016-2141

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.jminix</groupId>
 	<artifactId>jminix</artifactId>
 	<name>jminix</name>
-	<version>1.3.2</version>
+	<version>1.3.4-SNAPShOT</version>
 	<description>A simple embeddable restful JMX console</description>
 	<packaging>jar</packaging>
 	<url>http://www.jminix.org</url>
@@ -91,7 +91,7 @@
 		<dependency>
     		<groupId>org.jgroups</groupId>
     		<artifactId>jgroups</artifactId>
-    		<version>2.12.3.Final</version>
+    		<version>4.0.24.Final</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jasypt</groupId>

--- a/src/main/java/org/jminix/server/cluster/ClusterManager.java
+++ b/src/main/java/org/jminix/server/cluster/ClusterManager.java
@@ -25,8 +25,6 @@ import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
 import org.jasypt.util.binary.BasicBinaryEncryptor;
 import org.jasypt.util.binary.BinaryEncryptor;
 import org.jgroups.Address;
-import org.jgroups.Channel;
-import org.jgroups.ChannelException;
 import org.jgroups.JChannel;
 import org.jgroups.Message;
 import org.jgroups.ReceiverAdapter;
@@ -48,7 +46,7 @@ public abstract class ClusterManager extends ReceiverAdapter {
 	
 	protected String clusterName;
 	 
-	private Channel channel;
+	private JChannel channel;
 	
 	private boolean ipv6 = false;
 	
@@ -94,7 +92,7 @@ public abstract class ClusterManager extends ReceiverAdapter {
 			log.debug("Connecting to cluster "+clusterName);
 			channel.connect(clusterName);
 			
-		} catch (ChannelException e) {
+		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}        
 	}
@@ -148,8 +146,8 @@ public abstract class ClusterManager extends ReceiverAdapter {
 		
 		// Make sure that others see me.
 		try {
-			channel.send(new Message(null, null, encrypt(thisNode())));
-		} catch (ChannelException e) {
+			channel.send(new Message(null, encrypt(thisNode())));
+		} catch (Exception e) {
 			throw new RuntimeException(e);
 		} 
 	}
@@ -283,7 +281,7 @@ public abstract class ClusterManager extends ReceiverAdapter {
 	/**
 	 * The underlying jgroup channel. Defaults to a bare JChannel instance.
 	 */
-	public void setChannel(Channel channel) {
+	public void setChannel(JChannel channel) {
 		this.channel = channel;
 	}
 


### PR DESCRIPTION
jgroups before 4.0 has a critical security issue CVE-2016-2141

This PR bumps jgroups to 4.0.24.Final, small adaptations were needed in ClusterManager