### PR TITLE
Fix NPE in OperationResource

### DIFF
--- a/src/main/java/org/jminix/console/resource/OperationResource.java
+++ b/src/main/java/org/jminix/console/resource/OperationResource.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.StreamSupport;
+import java.util.Objects;
 
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
@@ -79,11 +79,7 @@ public class OperationResource extends AbstractTemplateResource
     @Post("*:txt|html|json")
     public Representation execute(Representation entity) throws ResourceException
     {
-        String[] stringParams = new Form(entity).getValuesArray("param");
-        
-        if(stringParams != null && isAllNulls(Arrays.asList(stringParams))) {
-            stringParams = nullToEmpty((String[]) ServletUtils.getRequest(getRequest()).getParameterMap().get("param"));
-        }
+        String[] stringParams = getStringParams(entity);
 
         String domain = unescape(getDecodedAttribute("domain"));
 
@@ -161,6 +157,16 @@ public class OperationResource extends AbstractTemplateResource
         }
     }
 
+    private String[] getStringParams(Representation entity) {
+        String[] stringParams = new Form(entity).getValuesArray("param");
+
+        if (stringParams == null || isAllNulls(stringParams)) {
+            stringParams = ServletUtils.getRequest(getRequest()).getParameterValues("param");
+        }
+
+        return stringParams != null ? stringParams : new String[0];
+    }
+
     @Override
     protected String getTemplateName()
     {
@@ -221,11 +227,8 @@ public class OperationResource extends AbstractTemplateResource
         }
     }
     
-    private boolean isAllNulls(Iterable<?> array) {
-        return StreamSupport.stream(array.spliterator(), true).allMatch(o -> o == null);
+    private boolean isAllNulls(String[] array) {
+        return Arrays.stream(array).allMatch(Objects::isNull);
     }
-    
-    private String[] nullToEmpty(String[] array) {
-        return array !=null ? array: new String[0];
-    }
+
 }


### PR DESCRIPTION
Make sure `stringParams` is never null, or the loop that parses this array will fail with a NullPointerException.

We were seeing exceptions like this in our app with 1.3.4, and the underlying operations were not being invoked. With this change, the UI works as normal.

<details>
  <summary>Stack trace</summary>

```
org.restlet.resource.ResourceException: Internal Server Error (500) - The server encountered an unexpected condition which prevented it from fulfilling the request
    at org.restlet.resource.ServerResource.doHandle(ServerResource.java:527)
    at org.restlet.resource.ServerResource.post(ServerResource.java:1341)
    at org.restlet.resource.ServerResource.doHandle(ServerResource.java:606)
    at org.restlet.resource.ServerResource.doNegotiatedHandle(ServerResource.java:662)
    at org.restlet.resource.ServerResource.doConditionalHandle(ServerResource.java:348)
    at org.restlet.resource.ServerResource.handle(ServerResource.java:1020)
    at org.restlet.resource.Finder.handle(Finder.java:236)
    at org.restlet.routing.Filter.doHandle(Filter.java:150)
    at org.restlet.routing.Filter.handle(Filter.java:197)
    at org.restlet.routing.Router.doHandle(Router.java:422)
    at org.restlet.routing.Router.handle(Router.java:641)
    at org.restlet.routing.Filter.doHandle(Filter.java:150)
    at org.restlet.routing.Filter.handle(Filter.java:197)
    at org.restlet.routing.Filter.doHandle(Filter.java:150)
    at org.restlet.routing.Filter.handle(Filter.java:197)
    at org.restlet.routing.Filter.doHandle(Filter.java:150)
    at org.restlet.engine.application.StatusFilter.doHandle(StatusFilter.java:140)
    at org.restlet.routing.Filter.handle(Filter.java:197)
    at org.restlet.routing.Filter.doHandle(Filter.java:150)
    at org.restlet.routing.Filter.handle(Filter.java:197)
    at org.restlet.engine.CompositeHelper.handle(CompositeHelper.java:202)
    at org.restlet.engine.application.ApplicationHelper.handle(ApplicationHelper.java:77)
    at org.restlet.Application.handle(Application.java:385)
    at org.restlet.routing.Filter.doHandle(Filter.java:150)
    at org.restlet.routing.Filter.handle(Filter.java:197)
    at org.restlet.routing.Router.doHandle(Router.java:422)
    at org.restlet.routing.Router.handle(Router.java:641)
    at org.restlet.routing.Filter.doHandle(Filter.java:150)
    at org.restlet.routing.Filter.handle(Filter.java:197)
    at org.restlet.routing.Router.doHandle(Router.java:422)
    at org.restlet.routing.Router.handle(Router.java:641)
    at org.restlet.routing.Filter.doHandle(Filter.java:150)
    at org.restlet.routing.Filter.handle(Filter.java:197)
    at org.restlet.engine.CompositeHelper.handle(CompositeHelper.java:202)
    at org.restlet.Component.handle(Component.java:408)
    at org.restlet.Server.handle(Server.java:507)
    at org.restlet.engine.connector.ServerHelper.handle(ServerHelper.java:63)
    at org.restlet.engine.adapter.HttpServerHelper.handle(HttpServerHelper.java:143)
    at org.restlet.ext.servlet.ServerServlet.service(ServerServlet.java:1117)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:584)
    at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:598)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1367)
    at org.eclipse.jetty.servlets.UserAgentFilter.doFilter(UserAgentFilter.java:77)
    at org.eclipse.jetty.servlets.GzipFilter.doFilter(GzipFilter.java:226)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1338)
    at com.lmr.utils.server.RequestLoggerTimer.doFilter(RequestLoggerTimer.java:116)
    at org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1338)
    at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:484)
    at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:229)
    at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1065)
    at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:413)
    at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:192)
    at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:999)
    at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:117)
    at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:111)
    at org.eclipse.jetty.server.Server.handle(Server.java:350)
    at org.eclipse.jetty.server.AbstractHttpConnection.handleRequest(AbstractHttpConnection.java:454)
    at org.eclipse.jetty.server.AbstractHttpConnection.content(AbstractHttpConnection.java:900)
    at org.eclipse.jetty.server.AbstractHttpConnection$RequestHandler.content(AbstractHttpConnection.java:954)
    at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:851)
    at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:235)
    at org.eclipse.jetty.server.AsyncHttpConnection.handle(AsyncHttpConnection.java:77)
    at org.eclipse.jetty.io.nio.SelectChannelEndPoint.handle(SelectChannelEndPoint.java:620)
    at org.eclipse.jetty.io.nio.SelectChannelEndPoint$1.run(SelectChannelEndPoint.java:46)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
    at java.lang.Thread.run(Thread.java:833)
```

</details>